### PR TITLE
Avoid type piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ define the one-argument version of `hash_method` and/or two argument version of 
 Here-in is a list of hash collisions that have been deemed to be acceptable in practice:
 
 - `stable_hash(sin) == stable_hash("Base.sin")`
+- `[1,2,3] == (1,2,3)`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ you want, so long as it is a type you have defined. For example:
     using DataFrames
     struct MyContext end
     StableHashTraits.hash_method(::DataFrame, ::MyContext) = UseProperties(:ByName)
-    stable_hash(DataFrames(a=1:2, b=1:2), context=MyContext())
+    stable_hash(DataFrames(a=1:2, b=1:2); context=MyContext())
 
 By default the context is `StableHashTraits.GlobalContext` and just two methods are defined.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ Your hash will be stable if the output for the given method remains the same: e.
 - `Missing`, `Nothing`: `UseQualifiedNamed()`
 - `VersionNumber`: `UseProperties()`
 
+## Avoiding Type Piracy
+
+It can be very tempting to define `hash_method` for types that were defined by another
+package or from Base. This is type piracy, and can easily lead to two different packags
+defining the same method: in this case, the method which gets used depends on the order of
+`using` statements... yuck.
+
+To avoid this problem, it is possible define a two argument version of `hash_method` (and/or
+a three argument version of `StableHashTraits.write`). This final arugment can be anything
+you want, so long as it is a type you have defined. For example:
+
+    using DataFrames
+    struct MyContext end
+    StableHashTraits.hash_method(::DataFrame, ::MyContext) = UseProperties(:ByName)
+    stable_hash(DataFrames(a=1:2, b=1:2), context=MyContext())
+
+By default the context is `StableHashTraits.GlobalContext` and just two methods are defined.
+
+    hash_method(x, context) = hash_method(x)
+    StableHashTraits.write(io, x, context) = StableHashTraits.write(io, x)
+
+In this way, you only need to define methods for the types that have non-default behavior
+for your context; furthermore, those who have no need of a particular context can simply
+define the one-argument version of `hash_method` and/or two argument version of `write`.
+
 ## Hashing gotcha's
 
 Here-in is a list of hash collisions that have been deemed to be acceptable in practice:

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -6,17 +6,18 @@ using CRC32c, TupleTools, Compat
 
 struct UseWrite end
 write(io, x) = Base.write(io, x)
-function stable_hash_helper(x, hash, ::UseWrite)
+function stable_hash_helper(x, hash, context, ::UseWrite)
     io = IOBuffer()
     write(io, x)
     return hash(take!(io))
 end
 
 struct UseIterate end
-function stable_hash_helper(x, hash, ::UseIterate)
+function stable_hash_helper(x, hash, context, ::UseIterate)
     result = hash(UInt8[])
     for el in x
-        result = hash(copy(reinterpret(UInt8, [stable_hash_helper(el, hash)])), result)
+        val = stable_hash_helper(el, hash, context, hash_method(el, context))
+        result = hash(copy(reinterpret(UInt8, [val])), result)
     end
     return result
 end
@@ -28,10 +29,10 @@ function UseProperties(by::Symbol=:ByOrder)
 end
 orderproperties(::UseProperties{:ByOrder}, props) = props
 orderproperties(::UseProperties{:ByName}, props) = TupleTools.sort(props; by=string)
-function stable_hash_helper(x, hash, use::UseProperties)
+function stable_hash_helper(x, hash, context, use::UseProperties)
     return stable_hash_helper((k => getproperty(x, k)
                                for k in orderproperties(use, propertynames(x))), hash,
-                              UseIterate())
+                              context, UseIterate())
 end
 
 struct UseQualifiedName{T}
@@ -41,29 +42,29 @@ UseQualifiedName() = UseQualifiedName(nothing)
 qualified_name(x::Function) = string(parentmodule(x), '.', nameof(x))
 qualified_name(::T) where {T} = string(parentmodule(T), '.', nameof(T))
 qualified_name(::Type{T}) where {T} = string(parentmodule(T), '.', nameof(T))
-function stable_hash_helper(x, hash, method::UseQualifiedName)
+function stable_hash_helper(x, hash, context, method::UseQualifiedName)
     str = qualified_name(x)
     if occursin(r"\.#[^.]*$", str)
         error("Annonymous types (those starting with `#`) cannot be hashed to a reliable value")
     end
-    result = stable_hash_helper(str, hash)
+    result = stable_hash_helper(str, hash, context, hash_method(str, context))
     if !isnothing(method.parent)
-        return hash(copy(reinterpret(UInt8, [stable_hash_helper(x, hash, method.parent)])),
-                    result)
+        val = stable_hash_helper(x, hash, context, method.parent)
+        return hash(copy(reinterpret(UInt8, [val])), result)
     else
         return result
     end
 end
 
 """
-    hash_method(x)
+    hash_method(x, [context])
 
 Retrieve the trait object that indicates how a type should be hashed using `stable_hash`.
 You should return one of the following values.
 
-1. `UseWrite()`: writes the object to a binary format using `StableHashTraits.write(io, x)` and
-    takes a hash of that (this is the default behavior). `StableHashTraits.write(io, x)` falls
-    back to `Base.write(io, x)` if no specialized methods are defined for x.
+1. `UseWrite()`: writes the object to a binary format using `StableHashTraits.write(io, x)`
+    and takes a hash of that (this is the default behavior). `StableHashTraits.write(io, x)`
+    falls back to `Base.write(io, x)` if no specialized methods are defined for x.
 2. `UseIterate()`: assumes the object is iterable and finds a hash of all elements
 3. `UseProperties()`: assumes a struct of some type and uses `propertynames` and
     `getproperty` to compute a hash of all fields. You can further customize its behavior by
@@ -90,7 +91,27 @@ properties are the same for `UseProperties`, the hash will be the same; etc...
 - `AbstractArray`, `Tuple`, `Pair`: `UseIterate()`
 - `Missing`, `Nothing`: `UseQualifiedNamed()`
 - `VersionNumber`: `UseProperties()`
+
+## Avoiding Type Piracy
+
+It can be very tempting to define `hash_method` for types that were defined by another
+package or from Base. This is type piracy, and can easily lead to two different packags
+defining the same method: in this case, the method which gets used depends on the order of
+`using` statements... yuck.
+
+To avoid this problem, it is possible define a two argument version of `hash_method`. This
+second arugment can be anything you want, so long as it is a type you have defined. A pass
+through method means that if you haven't defined a method for your context it falls back to
+the default single-argument `hash_method`. For example:
+
+    using DataFrames
+    struct MyContext end
+    StableHashTraits.hash_method(::DataFrame, ::MyContext) = UseProperties(:ByName)
+    stable_hash(DataFrames(a=1:2, b=1:2), context=MyContext())
+
+```
 """
+hash_method(x, context) = hash_method(x)
 hash_method(::Any) = UseWrite()
 hash_method(::AbstractArray) = UseIterate()
 hash_method(::AbstractRange) = UseProperties()
@@ -103,10 +124,8 @@ hash_method(::Nothing) = UseQualifiedName()
 hash_method(::Missing) = UseQualifiedName()
 hash_method(::VersionNumber) = UseProperties()
 
-stable_hash_helper(x, hash) = stable_hash_helper(x, hash, hash_method(x))
-
 """
-    stable_hash(arg1, arg2, ...; alg=crc32c)
+    stable_hash(arg1, arg2, ...; context=nothing, alg=crc32c)
 
 Create a stable hash of the given objects. This is intended to remain unchanged
 across julia verisons. The default fallback method is to write the object and
@@ -120,9 +139,11 @@ To change the hash algorithm used, pass a different funciton to `alg`. The
 function should take one required argument (value to hash) and a second,
 optional argument (a hash value to mix).
 
+The `context` value gets passed as the second argument to [`hash_method`](@ref).
+
 """
-function stable_hash(obj...; alg=crc32c)
-    return stable_hash_helper(obj, alg)
+function stable_hash(obj...; context, alg=crc32c)
+    return stable_hash_helper(x, alg, context, hash_method(x, context))
 end
 
 end

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -14,7 +14,7 @@ Fall back methods are defined as follows:
     write(io, x, context) = write(io, x)
     write(io, x) = Base.write(io, x)
 
-Users of `StableHashTraits` can overwrite either the 2 or 3 arugment version for 
+Users of `StableHashTraits` can overwrite either the 2 or 3 argument version for 
 their types to customize the behavior of `stable_hash`. 
 
 See also: [`StableHashTraits.hash_method`](@ref).
@@ -114,14 +114,14 @@ package or from Base. This is type piracy, and can easily lead to two different 
 defining the same method: in this case, the method which gets used depends on the order of
 `using` statements... yuck.
 
-To avoid this problem, it is possible define a two argument version of `hash_method` (and/or
-a three argument version of `StableHashTraits.write`). This final arugment can be anything
-you want, so long as it is a type you have defined. For example:
+To avoid this problem, it is possible to define a two argument version of `hash_method`
+(and/or a three argument version of `StableHashTraits.write`). This final arugment can be
+anything you want, so long as it is a type you have defined. For example:
 
     using DataFrames
     struct MyContext end
     StableHashTraits.hash_method(::DataFrame, ::MyContext) = UseProperties(:ByName)
-    stable_hash(DataFrames(a=1:2, b=1:2), context=MyContext())
+    stable_hash(DataFrames(a=1:2, b=1:2); context=MyContext())
 
 By default the context is `StableHashTraits.GlobalContext` and just two methods are defined.
 
@@ -160,7 +160,7 @@ consider irrelevant for its hash.
 
 You can customize how an object is hashed using `hash_method`.
 
-To change the hash algorithm used, pass a different funciton to `alg`. The
+To change the hash algorithm used, pass a different function to `alg`. The
 function should take one required argument (value to hash) and a second,
 optional argument (a hash value to mix).
 

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -169,7 +169,7 @@ and the third argument to [`StableHashTraits.write`](@ref)
 
 """
 function stable_hash(obj...; context=GlobalContext(), alg=crc32c)
-    return stable_hash_helper(x, alg, context, hash_method(x, context))
+    return stable_hash_helper(obj, alg, context, hash_method(obj, context))
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,7 +73,7 @@ StableHashTraits.hash_method(::TestType, ::MyContext) = UseProperties(UsePropert
     @test stable_hash(TestType4(1, 2)) != stable_hash(TestType3(1, 2))
     @test stable_hash(TestType(1, 2)) == stable_hash(TestType3(2, 1))
     @test stable_hash(TestType(1, 2)) != stable_hash(TestType4(2, 1))
-    @test stable_hash(TestType(1, 2), context=MyContext()) == stable_hash(TestType2(1, 2))
-    @test stable_hash(TestType(1, 2), context=MyContext()) == 
-          stable_hash(TestType2(1, 2), context=MyContext())
+    @test stable_hash(TestType(1, 2); context=MyContext()) == stable_hash(TestType2(1, 2))
+    @test stable_hash(TestType(1, 2); context=MyContext()) ==
+          stable_hash(TestType2(1, 2); context=MyContext())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,8 +35,10 @@ StableHashTraits.hash_method(::TestType) = UseProperties()
 StableHashTraits.hash_method(::TestType2) = UseQualifiedName(UseProperties())
 StableHashTraits.hash_method(::TestType3) = UseProperties(:ByName)
 StableHashTraits.hash_method(::TestType4) = UseProperties()
-StableHashTraits.hash_method(::TypeType) = UseProperties()
 StableHashTraits.write(io, x::TestType5) = write(io, reverse(x.bob))
+
+struct MyContext end
+StableHashTraits.hash_method(::TestType, ::MyContext) = UseProperties(UseProperties())
 
 @testset "StableHashTraits.jl" begin
     @test stable_hash([1, 2, 3]) == 0x1a366aea
@@ -71,4 +73,7 @@ StableHashTraits.write(io, x::TestType5) = write(io, reverse(x.bob))
     @test stable_hash(TestType4(1, 2)) != stable_hash(TestType3(1, 2))
     @test stable_hash(TestType(1, 2)) == stable_hash(TestType3(2, 1))
     @test stable_hash(TestType(1, 2)) != stable_hash(TestType4(2, 1))
+    @test stable_hash(TestType(1, 2), context=MyContext()) == stable_hash(TestType2(1, 2))
+    @test stable_hash(TestType(1, 2), context=MyContext()) == 
+          stable_hash(TestType2(1, 2), context=MyContext())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,10 +35,11 @@ StableHashTraits.hash_method(::TestType) = UseProperties()
 StableHashTraits.hash_method(::TestType2) = UseQualifiedName(UseProperties())
 StableHashTraits.hash_method(::TestType3) = UseProperties(:ByName)
 StableHashTraits.hash_method(::TestType4) = UseProperties()
+StableHashTraits.hash_method(::TypeType) = UseProperties()
 StableHashTraits.write(io, x::TestType5) = write(io, reverse(x.bob))
 
 struct MyContext end
-StableHashTraits.hash_method(::TestType, ::MyContext) = UseProperties(UseProperties())
+StableHashTraits.hash_method(::TestType, ::MyContext) = UseQualifiedName(UseProperties())
 
 @testset "StableHashTraits.jl" begin
     @test stable_hash([1, 2, 3]) == 0x1a366aea
@@ -73,7 +74,7 @@ StableHashTraits.hash_method(::TestType, ::MyContext) = UseProperties(UsePropert
     @test stable_hash(TestType4(1, 2)) != stable_hash(TestType3(1, 2))
     @test stable_hash(TestType(1, 2)) == stable_hash(TestType3(2, 1))
     @test stable_hash(TestType(1, 2)) != stable_hash(TestType4(2, 1))
-    @test stable_hash(TestType(1, 2); context=MyContext()) == stable_hash(TestType2(1, 2))
-    @test stable_hash(TestType(1, 2); context=MyContext()) ==
+    @test stable_hash(TestType(1, 2); context=MyContext()) != stable_hash(TestType(1, 2))
+    @test stable_hash(TestType2(1, 2); context=MyContext()) ==
           stable_hash(TestType2(1, 2); context=MyContext())
 end


### PR DESCRIPTION
This makes it easier to avoid type piracy when definting new `hash_method` by allowing for an optional second argument.

TODO:

- [x] create tests