### PR TITLE
Implement `transform`

### DIFF
--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -87,11 +87,9 @@ x`).
     given transform applies, but you need not implement a method that uses context unless you
     want to (since the fallback method is `transform(x, context) = transform(x)`).
 
-The purpose of `transform` is to provide flexibility about which hash methods get applied to
-what parts of an object. `with_hash_method(x, method)` forces use of `method` for object `x`.
-Used together, you can request that various parts of your object get hashed in any way you
-wish. For example:
-
+In practice, the return value of `transform` is normally a tuple of multuple
+calls to [`with_hash_method`](@ref). For example:
+    
 ```julia
 struct MyObject
     x::AbstractRange

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -88,11 +88,9 @@ x`).
     want to (since the fallback method is `transform(x, context) = transform(x)`).
 
 The purpose of `transform` is to provide flexibility about which hash methods get applied to
-what parts of an object you can use a combination of `transform` and `with_hash_method`. The
-`transform` function is applied before selecting a hash method and defualts to `transform(x)
-= x`, `with_hash_method(x, method)` forces use of `method` for object `x`. Used together,
-you can request that various parts of your object get hashed in any way you wish. For
-example:
+what parts of an object. `with_hash_method(x, method)` forces use of `method` for object `x`.
+Used together, you can request that various parts of your object get hashed in any way you
+wish. For example:
 
 ```julia
 struct MyObject

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -184,7 +184,7 @@ end
 ##### Forced Hash Methods 
 #####
 
-struct WithMethod{T, M}
+struct WithMethod{T,M}
     val::T
     method::M
 end

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -318,9 +318,11 @@ The `context` value gets passed as the second argument to [`hash_method`](@ref),
 third argument to [`StableHashTraits.write`](@ref)
 
 """
-function stable_hash(obj...; context=GlobalContext(), alg=crc32c)
-    return digest!(stable_hash_helper(obj, setup_hash(alg), context,
-                                      hash_method(obj, context)))
+function stable_hash(args...; context=GlobalContext(), alg=crc32c)
+    # we always choose `UseIterate` here because that's how we want to hash multiple args,
+    # regardless of how tuple hashing is defined.
+    return digest!(stable_hash_helper(args, setup_hash(alg), context,
+                                      UseIterate()))
 end
 
 end

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -321,8 +321,7 @@ third argument to [`StableHashTraits.write`](@ref)
 function stable_hash(args...; context=GlobalContext(), alg=crc32c)
     # we always choose `UseIterate` here because that's how we want to hash multiple args,
     # regardless of how tuple hashing is defined.
-    return digest!(stable_hash_helper(args, setup_hash(alg), context,
-                                      UseIterate()))
+    return digest!(stable_hash_helper(args, setup_hash(alg), context, UseIterate()))
 end
 
 end

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -105,6 +105,26 @@ end
 
 This would hash `MyObject` by hasing the data (x and y), but not the notes about that data.
 
+
+By changing the context, you can change how something in that object gets hashed.
+
+```julia
+struct CustomHashObject
+    x::AbstractRange
+    y::Vector{Float64}
+end
+struct CustomContext{T}
+    old_context::T
+end
+function StableHashTraits.transform(val::CustomHashObject, context)
+    return (val.x, val.y), CustomContext(context)
+end
+StableHashTraits.hash_method(x::AbstractRange, ::CustomContext) = UseIterate()
+StableHashTraits.hash_method(x, context::CustomContext) = hash_method(x, context.old_context)
+```
+
+This would ensure that the range (`x`) gets hashed by iterating of its contents, preserving
+the behavior for all other objects that were true in the prior context.
 """
 transform(x, context) = transform(x), context
 transform(x) = x

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -106,7 +106,7 @@ then iterating over the characters specified in `y`.
 """
 transform(x, context) = transform(x)
 transform(x) = x
-# NOTE: we need only implement this for `UseIterate` because all hash methods that
+# NOTE: we need only call `transform` in `UseIterate` because all other hash methods that
 # need to hash multiple subcomponents make use of of the `UseIterate` method.
 
 function stable_hash_helper(x, hash, context, ::UseIterate)

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -253,8 +253,8 @@ properties are the same for `UseProperties`, the hash will be the same; etc...
 - `UUID`: `UseProperties()`
 - `Dates.AbstractTime`: `UseProperties()`
 
-For more complicated scenarios where a simple definition of `hash_method` will not
-suffice, refer to the documentaiton of `transform` and `write`.
+For more complicated scenarios where impleneting `hash_method` will not suffice, refer to
+the documentaiton of `transform` and `write`.
 
 ## Avoiding Type Piracy Using a Context Object
 
@@ -264,7 +264,7 @@ defining the same method: in this case, the method which gets used depends on th
 `using` statements... yuck.
 
 To avoid this problem, it is possible to define a version of any method you specialize (e.g.
-`hash_method`, `transform` and/or `write`) with one additional argument. This final arugment
+`hash_method`, `transform` and/or `write`) with one additional argument. This final argument
 can be anything you want, so long as it is a type you have defined. For example:
 
     using DataFrames

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,24 @@ struct NonTableStruct
 end
 StableHashTraits.hash_method(::NonTableStruct) = UseProperties()
 
+struct NestedObject{T}
+    x::T
+    index::Int
+end
+
+struct BasicHashObject
+    x::AbstractRange
+    y::String
+end
+StableHashTraits.hash_method(x::BasicHashObject) = UseProperties()
+struct CustomHashObject
+    x::AbstractRange
+    y::String
+end
+function StableHashTraits.transform(val::CustomHashObject)
+    return (with_hash_method(val.x, UseIterate()), with_hash_method(val.y, UseIterate()))
+end
+
 @testset "StableHashTraits.jl" begin
     # reference tests to ensure hash consistency
     @test stable_hash(()) == 0x48674bc7
@@ -119,6 +137,7 @@ StableHashTraits.hash_method(::NonTableStruct) = UseProperties()
     @test stable_hash([1 2; 3 4]; alg=sha1) == bytes
 
     # various (in)equalities
+    @test stable_hash(CustomHashObject(1:5, "foo")) != stable_hash(BasicHashObject(1:5, "foo"))
     @test stable_hash([]) != stable_hash([(), (), ()])
     @test stable_hash([1 2; 3 4]) != stable_hash(vec([1 2; 3 4]))
     @test stable_hash([1 2; 3 4]) == stable_hash([1 3; 2 4]')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,15 +58,17 @@ end
 
 struct BasicHashObject
     x::AbstractRange
-    y::String
+    y::Vector{Float64}
+    notes::String
 end
 StableHashTraits.hash_method(x::BasicHashObject) = UseProperties()
 struct CustomHashObject
     x::AbstractRange
-    y::String
+    y::Vector{Float64}
+    notes::String
 end
 function StableHashTraits.transform(val::CustomHashObject)
-    return (with_hash_method(val.x, UseIterate()), with_hash_method(val.y, UseIterate()))
+    return (val.x, val.y)
 end
 
 @testset "StableHashTraits.jl" begin
@@ -137,8 +139,8 @@ end
     @test stable_hash([1 2; 3 4]; alg=sha1) == bytes
 
     # various (in)equalities
-    @test stable_hash(CustomHashObject(1:5, "foo")) !=
-          stable_hash(BasicHashObject(1:5, "foo"))
+    @test stable_hash(CustomHashObject(1:5, 1:10, "foo")) !=
+          stable_hash(BasicHashObject(1:5, 1:10, "foo"))
     @test stable_hash([]) != stable_hash([(), (), ()])
     @test stable_hash([1 2; 3 4]) != stable_hash(vec([1 2; 3 4]))
     @test stable_hash([1 2; 3 4]) == stable_hash([1 3; 2 4]')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,7 +137,8 @@ end
     @test stable_hash([1 2; 3 4]; alg=sha1) == bytes
 
     # various (in)equalities
-    @test stable_hash(CustomHashObject(1:5, "foo")) != stable_hash(BasicHashObject(1:5, "foo"))
+    @test stable_hash(CustomHashObject(1:5, "foo")) !=
+          stable_hash(BasicHashObject(1:5, "foo"))
     @test stable_hash([]) != stable_hash([(), (), ()])
     @test stable_hash([1 2; 3 4]) != stable_hash(vec([1 2; 3 4]))
     @test stable_hash([1 2; 3 4]) == stable_hash([1 3; 2 4]')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,17 +59,20 @@ end
 struct BasicHashObject
     x::AbstractRange
     y::Vector{Float64}
-    notes::String
 end
 StableHashTraits.hash_method(x::BasicHashObject) = UseProperties()
 struct CustomHashObject
     x::AbstractRange
     y::Vector{Float64}
-    notes::String
 end
-function StableHashTraits.transform(val::CustomHashObject)
-    return (val.x, val.y)
+struct CustomContext{T}
+    old_context::T
 end
+function StableHashTraits.transform(val::CustomHashObject, context)
+    return (val.x, val.y), CustomContext(context)
+end
+StableHashTraits.hash_method(x::AbstractRange, ::CustomContext) = UseIterate()
+StableHashTraits.hash_method(x, context::CustomContext) = StableHashTraits.hash_method(x, context.old_context)
 
 @testset "StableHashTraits.jl" begin
     # reference tests to ensure hash consistency
@@ -139,8 +142,8 @@ end
     @test stable_hash([1 2; 3 4]; alg=sha1) == bytes
 
     # various (in)equalities
-    @test stable_hash(CustomHashObject(1:5, 1:10, "foo")) !=
-          stable_hash(BasicHashObject(1:5, 1:10, "foo"))
+    @test stable_hash(CustomHashObject(1:5, 1:10)) !=
+          stable_hash(BasicHashObject(1:5, 1:10))
     @test stable_hash([]) != stable_hash([(), (), ()])
     @test stable_hash([1 2; 3 4]) != stable_hash(vec([1 2; 3 4]))
     @test stable_hash([1 2; 3 4]) == stable_hash([1 3; 2 4]')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,7 +72,9 @@ function StableHashTraits.transform(val::CustomHashObject, context)
     return (val.x, val.y), CustomContext(context)
 end
 StableHashTraits.hash_method(x::AbstractRange, ::CustomContext) = UseIterate()
-StableHashTraits.hash_method(x, context::CustomContext) = StableHashTraits.hash_method(x, context.old_context)
+function StableHashTraits.hash_method(x, context::CustomContext)
+    return StableHashTraits.hash_method(x, context.old_context)
+end
 
 @testset "StableHashTraits.jl" begin
     # reference tests to ensure hash consistency


### PR DESCRIPTION
This defines two new methods (as per title) that should ease customization of an object's hash method. Read through the new docstrings for more details.

TODO:
- [x] Copy over final docstring to README