### PR TITLE
Auto generated doc strings are computed during precompilation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ following values, typically based only on the *type* of its input.
     - `stable_typename_id`: Get the qualified name of an object's type, e.g. `Base.String` and return 64 bit hash of this string
     - `stable_type_id`: Get the qualified name and type parameters of a type, e.g.
        `Base.Vector{Int}`, and return a 64 bit hash of this string.
-5. `@ConstantHash(x)`: at compile time, hash the literal (constant) string or number using `sha256`
-  and include the first 64 bits as a constant number that is recursively hashed
-  using the `WriteHash` method.
+5. `@ConstantHash(x)`: at compile time, hash the literal (constant) string or number using
+    `sha256` and include the first 64 bits as a constant number that is recursively hashed
+    using the `WriteHash` method.
 6. `Tuple`: apply multiple methods to hash the object, and then recursively hash their
     results. For example: `(@ConstantHash("header"), StructHash())` would compute a hash for
     both the string `"header"` and the fields of the object, and then recursively hash

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -58,14 +58,14 @@ function stable_hash(x, context; alg=sha256)
 end
 
 # extract contents of README so we can insert it into the some of the docstrings
-function __init__()
-    readme = read(joinpath(pkgdir(StableHashTraits), "README.md"), String)
+let
+    readme_file = joinpath(pkgdir(StableHashTraits), "README.md")
+    Base.include_dependency(readme_file)
+    readme = read(readme_file, String)
     traits = match(r"START_HASH_TRAITS -->(.*)<!-- END_HASH_TRAITS"s, readme).captures[1]
     contexts = match(r"START_CONTEXTS -->(.*)<!-- END_CONTEXTS"s, readme).captures[1]
     # TODO: if we ever generate `Documenter.jl` docs we need to revise the
     # links to symbols here
-
-    traits, contexts
 
     @doc """
     hash_method(x, [context])
@@ -77,8 +77,6 @@ function __init__()
 
     $contexts
     """ hash_method
-
-    return nothing
 end
 
 function hash_method end

--- a/src/StableHashTraits.jl
+++ b/src/StableHashTraits.jl
@@ -68,7 +68,7 @@ let
     # links to symbols here
 
     @doc """
-    hash_method(x, [context])
+        StableHashTraits.hash_method(x, [context])
 
     Retrieve the trait object that indicates how a type should be hashed using `stable_hash`.
     You should return one of the following values.


### PR DESCRIPTION
## Description

This changes how docstrings get computed from the README. They occur at precompilation and we use `Base.include_dependency` to ensure that a change to the README invalidates the precompilation cache.
