### PR TITLE
Fix compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "1.1.2"
+version = "1.1.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -11,6 +11,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Compat = "3, 4"
+SHA = "0.7"
 Tables = "1.7"
 TupleTools = "1"
 julia = "1.6"


### PR DESCRIPTION
## Description

Setup compat bounds for `SHA`, and fix the version (since the old release didn't merge).

