### PR TITLE
Fix SHA Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Compat = "3, 4"
-SHA = "0.7"
+SHA = "0.7, 1"
 Tables = "1.7"
 TupleTools = "1"
 julia = "1.6"


### PR DESCRIPTION
## Description

Changes compat bounds for SHA to make it easier to install for downstream users in CI (where in e.g. Julia 1.6 the version of SHA is the version of julia).