### PR TITLE
Only use julia-actions/cache instead of manual cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,18 +35,10 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/cache@v2
+        with:
+          cache-compiled: "true"
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/generated-CI.yml
+++ b/.github/workflows/generated-CI.yml
@@ -31,12 +31,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: generated-function-test-${{ hashFiles('**/Project.toml') }}
       - uses: julia-actions/julia-buildpkg@v1
       - name: "Run `dev StableHashTraits`"
         shell: julia --color=yes --project {0}
@@ -46,6 +40,8 @@ jobs:
           Pkg.develop(PackageSpec(; path="."))
           Pkg.status()
       - uses: julia-actions/cache@v2
+        with:
+          cache-compiled: "true"
       - uses: julia-actions/julia-runtest@main
         with:
           compiled_modules: 'no'


### PR DESCRIPTION
Removes a leftover use of `actions/cache` since `julia-actions/cache` is being used.
