### PR TITLE
stablize type hash of `Base.Fix1`  and `Base.Fix2` for julia 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -348,10 +348,21 @@ Get a stable name of `T`. This is a helpful utility for writing your own methods
 [`StableHashTraits.transform_type_value`](@ref). The stable name is computed from `nameof`.
 Anonymous names (e.g. `module_nameof_string(x -> x+1)`) throw an error, as no stable name is
 possible in this case.
+
+## Implementation notes
+
+To support stable hash values for Julia ≤1.11, the Julia 1.12 types
+`Base.Fix{2}` and `Base.Fix{1}` are printed as `Base.Fix2` and `Base.Fix1`.
+Julia 1.12 generalized Fix1 and Fix2 to the more generic Fix{N} type.
 """
 @inline nameof_string(m::Module) = nameof_(m)
 @inline nameof_string(::T) where {T} = nameof_(T)
 @inline nameof_string(::Type{T}) where {T} = handle_unions_(T, nameof_)
+@static if VERSION >= v"1.12.0-0"
+    @inline nameof_string(::Type{<:Base.Fix1}) = "Fix1"
+    @inline nameof_string(::Type{<:Base.Fix2}) = "Fix2"
+end
+
 hoist_type(::typeof(nameof_string)) = true
 @inline function nameof_(::Type{T}) where {T}
     return validate_name(String(nameof(T)))

--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -275,7 +275,8 @@ throw an error, as no stable name is possible in this case. In Julia 1.12 `Base.
 printed as `Base.Fix1` and `Base.Fix{2}` as `Base.Fix2` to remain stable with their outputs
 in Julia `1.11`. (Julia 1.12 generalized `Fix1` and `Fix2` to `Fix{N}`).
 
-!!! danger "A type's module often changes" The module of many types are considered an
+!!! danger "A type's module often changes"
+    The module of many types are considered an
     implementation detail and can change between non-breaking versions of a package. For
     this reason uses of `module_nameof_string` must be explicitly specified by user of
     `StableHashTraits`. This function is not used internally nor `HashVersion{4}` for types

--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -271,13 +271,14 @@ of [`StableHashTraits.transform_type`](@ref) and
 [`StableHashTraits.transform_type_value`](@ref). The stable name includes the name of the
 module that `T` was defined in. Any uses of `Core` are replaced with `Base` to keep the name
 stable across versions of julia. Anonymous names (e.g. `module_nameof_string(x -> x+1)`)
-throw an error, as no stable name is possible in this case.
+throw an error, as no stable name is possible in this case. In Julia 1.12 `Base.Fix{1}` is
+printed as `Base.Fix1` and `Base.Fix{2}` as `Base.Fix2` to remain stable with their outputs
+in Julia `1.11`. (Julia 1.12 generalized `Fix1` and `Fix2` to `Fix{N}`).
 
-!!! danger "A type's module often changes"
-    The module of many types are considered an
+!!! danger "A type's module often changes" The module of many types are considered an
     implementation detail and can change between non-breaking versions of a package. For
     this reason uses of `module_nameof_string` must be explicitly specified by user of
-    `StableHashTraits`. This function is not used internally hor `HashVersion{4}` for types
+    `StableHashTraits`. This function is not used internally nor `HashVersion{4}` for types
     that are not defined in `StableHashTraits`.
 """
 @inline module_nameof_string(::T) where {T} = module_nameof_string(T)
@@ -285,6 +286,11 @@ throw an error, as no stable name is possible in this case.
 @inline module_nameof_string(::Type{T}) where {T} = handle_unions_(T, module_nameof_)
 @inline function module_nameof_(::Type{T}) where {T}
     return validate_name(clean_module(parentmodule(T)) * "." * String(nameof(T)))
+end
+
+@static if VERSION >= v"1.12.0-0"
+    @inline module_nameof_string(::Type{<:Base.Fix1}) = "Base.Fix1"
+    @inline module_nameof_string(::Type{<:Base.Fix2}) = "Base.Fix2"
 end
 
 # TODO: use `Pluto.is_inside_pluto` when/if it is implemented

--- a/test/references/ref27_4_crc32c.txt
+++ b/test/references/ref27_4_crc32c.txt
@@ -1,0 +1,1 @@
+Base.Fix2

--- a/test/references/ref27_4_sha1.txt
+++ b/test/references/ref27_4_sha1.txt
@@ -1,0 +1,1 @@
+Base.Fix2

--- a/test/references/ref27_4_sha256.txt
+++ b/test/references/ref27_4_sha256.txt
@@ -1,0 +1,1 @@
+Base.Fix2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,8 @@ include("setup_tests.jl")
                                                       d=(d1=1, d2=2)))))
                 @test_reference("references/ref26_$(V)_$(nameof(hashfn)).txt",
                                 bytes2hex_(test_hash(2 => 3)))
+                @test_reference("references/ref27_$(V)_$(nameof(hashfn)).txt",
+                                StableHashTraits.module_nameof_string(==(1)))
             end
 
             # dictionary like


### PR DESCRIPTION
`Fix1` and `Fix2` got generailzed to `Fix{N}` in Julia 1.12, changing their `nameof` output, which is used by `StableHashTraits` to hash the type of an object. This fixes the string output of `Fix{1}` to `Fix1` and `Fix{2}` to `Fix2` to avoid the regression. 