### PR TITLE
Concrete dispatch in `split_union`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "2.0.2"
+version = "2.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/transformer_traits.jl
+++ b/src/transformer_traits.jl
@@ -240,7 +240,9 @@ split_union(array) = TransformIdentity(array)
 function split_union(array::AbstractArray{Union{N,M}}) where {N,M}
     # NOTE: when an abstract array is e.g. AbstractArray{Int}, N becomes
     # Int and M is left as undefined, we just need to hash this array
-    !@isdefined(M) && return TransformIdentity(array)
+    if !(eltype(array) isa Union)
+        return TransformIdentity(array)
+    end
     # special case null and singleton-types, since we don't need to hash their content at
     # all
     if StructType(N) isa StructTypes.NullType ||

--- a/test/benchmark_records.md
+++ b/test/benchmark_records.md
@@ -217,3 +217,30 @@ on the performance of benchmarks for hash version 4.
   15 │ strings     sha256     4          1.753 ms    1.707 ms     0.973521
   16 │ missings    sha256     4          477.875 μs  443.042 μs   0.927109
 ```
+
+# Version 2.1.0
+
+This version improves type stability within `split_union`.
+Benchmarks:
+```
+16×6 DataFrame
+ Row │ benchmark   hash       version    base        trait       ratio
+     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64
+─────┼─────────────────────────────────────────────────────────────────────
+   1 │ dicts       crc        4          1.573 ms    94.328 ms   59.9554
+   2 │ structs     crc        4          14.931 μs   700.719 μs  46.9305
+   3 │ tuples      crc        4          15.225 μs   461.652 μs  30.322
+   4 │ numbers     crc        4          9.248 μs    261.929 μs  28.3228
+   5 │ dataframes  crc        4          24.779 μs   412.719 μs  16.656
+   6 │ symbols     crc        4          1.103 ms    1.582 ms     1.43467
+   7 │ missings    crc        4          297.214 μs  300.940 μs   1.01254
+   8 │ strings     crc        4          1.242 ms    392.245 μs   0.315832
+   9 │ dicts       sha256     4          2.617 ms    152.035 ms  58.0849
+  10 │ structs     sha256     4          615.561 μs  1.996 ms     3.24226
+  11 │ tuples      sha256     4          614.088 μs  1.699 ms     2.767
+  12 │ dataframes  sha256     4          623.278 μs  1.049 ms     1.6832
+  13 │ numbers     sha256     4          306.494 μs  489.522 μs   1.59717
+  14 │ symbols     sha256     4          2.387 ms    3.390 ms     1.42063
+  15 │ missings    sha256     4          654.759 μs  675.435 μs   1.03158
+  16 │ strings     sha256     4          2.397 ms    2.032 ms     0.847944
+```


### PR DESCRIPTION
## Description

Currently, this package checks whether a method static parameter is undefined within `split_union`. This is not concretely inferred, which leads to the rest of the function being compiled unnecessarily. In this PR, we change this to dispatch on whether the `eltype` is a `Union`, which is inferred concretely. If it isn't, there is no splitting required. This seems to be the intent of the branch from the comment above it.

## Benchmarks

### Before
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.648 ms    120.981 ms  73.3978
   2 │ structs     crc        4          16.425 μs   761.625 μs  46.3699
   3 │ tuples      crc        4          17.235 μs   495.447 μs  28.7466
   4 │ numbers     crc        4          7.177 μs    199.481 μs  27.7945
   5 │ dataframes  crc        4          25.100 μs   449.884 μs  17.9237
   6 │ symbols     crc        4          1.155 ms    1.695 ms     1.46757
   7 │ missings    crc        4          306.436 μs  339.972 μs   1.10944
   8 │ strings     crc        4          1.239 ms    343.324 μs   0.277077
   9 │ dicts       sha256     4          2.349 ms    153.493 ms  65.3555
  10 │ structs     sha256     4          628.266 μs  2.054 ms     3.26926
  11 │ tuples      sha256     4          636.174 μs  1.765 ms     2.7749
  12 │ dataframes  sha256     4          653.450 μs  1.093 ms     1.67228
  13 │ numbers     sha256     4          321.190 μs  509.403 μs   1.58599
  14 │ symbols     sha256     4          2.444 ms    3.642 ms     1.49019
  15 │ missings    sha256     4          673.558 μs  688.102 μs   1.02159
  16 │ strings     sha256     4          2.515 ms    2.091 ms     0.831289
```
### After
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.573 ms    94.328 ms   59.9554
   2 │ structs     crc        4          14.931 μs   700.719 μs  46.9305
   3 │ tuples      crc        4          15.225 μs   461.652 μs  30.322
   4 │ numbers     crc        4          9.248 μs    261.929 μs  28.3228
   5 │ dataframes  crc        4          24.779 μs   412.719 μs  16.656
   6 │ symbols     crc        4          1.103 ms    1.582 ms     1.43467
   7 │ missings    crc        4          297.214 μs  300.940 μs   1.01254
   8 │ strings     crc        4          1.242 ms    392.245 μs   0.315832
   9 │ dicts       sha256     4          2.617 ms    152.035 ms  58.0849
  10 │ structs     sha256     4          615.561 μs  1.996 ms     3.24226
  11 │ tuples      sha256     4          614.088 μs  1.699 ms     2.767
  12 │ dataframes  sha256     4          623.278 μs  1.049 ms     1.6832
  13 │ numbers     sha256     4          306.494 μs  489.522 μs   1.59717
  14 │ symbols     sha256     4          2.387 ms    3.390 ms     1.42063
  15 │ missings    sha256     4          654.759 μs  675.435 μs   1.03158
  16 │ strings     sha256     4          2.397 ms    2.032 ms     0.847944
```