### PR TITLE
Concrete dispatch in `handle_unions_`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableHashTraits"
 uuid = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 authors = ["Beacon Biosignals, Inc."]
-version = "2.0.2"
+version = "2.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -323,13 +323,13 @@ end
     return validate_name(clean_module(parentmodule(T)) * "." * String(nameof(T)))
 end
 
-function handle_unions_(::Type{Union{A,B}}, namer) where {A,B}
-    !@isdefined(A) && !@isdefined(B) && return ""
-    !@isdefined(B) && return handle_function_types_(A, namer)
-    # NOTE: The following line never gets run, because of the way julia's type dispatch
-    # is currently implemented, but it is here to avoid regressions in future julia
-    # versions
-    !@isdefined(A) && return handle_function_types_(B, namer)
+function handle_unions_(::Type{T}, namer) where {T}
+    if T isa Union
+        return _handle_unions_(T, namer)
+    end
+    return handle_function_types_(T, namer)
+end
+function _handle_unions_(::Type{Union{A,B}}, namer) where {A,B}
     return handle_unions_(A, namer) * "," * handle_unions_(B, namer)
 end
 # not all types are concrete, so they must be passed through a generic "handle_unions_"

--- a/test/benchmark_records.md
+++ b/test/benchmark_records.md
@@ -217,3 +217,30 @@ on the performance of benchmarks for hash version 4.
   15 │ strings     sha256     4          1.753 ms    1.707 ms     0.973521
   16 │ missings    sha256     4          477.875 μs  443.042 μs   0.927109
 ```
+
+# Version 2.1.0
+
+This version improves type-stability in handling `Union` types.
+Benchmarks:
+```
+16×6 DataFrame
+ Row │ benchmark   hash       version    base        trait       ratio
+     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64
+─────┼─────────────────────────────────────────────────────────────────────
+   1 │ dicts       crc        4          1.588 ms    102.622 ms  64.6296
+   2 │ structs     crc        4          17.277 μs   752.080 μs  43.5307
+   3 │ tuples      crc        4          17.358 μs   529.185 μs  30.4865
+   4 │ numbers     crc        4          6.791 μs    186.629 μs  27.4818
+   5 │ dataframes  crc        4          27.073 μs   438.643 μs  16.2022
+   6 │ symbols     crc        4          1.168 ms    1.619 ms     1.38543
+   7 │ missings    crc        4          302.562 μs  315.324 μs   1.04218
+   8 │ strings     crc        4          1.223 ms    334.434 μs   0.273366
+   9 │ dicts       sha256     4          2.281 ms    133.743 ms  58.6238
+  10 │ structs     sha256     4          643.719 μs  2.024 ms     3.145
+  11 │ tuples      sha256     4          628.626 μs  1.792 ms     2.8509
+  12 │ dataframes  sha256     4          653.632 μs  1.084 ms     1.65908
+  13 │ numbers     sha256     4          321.180 μs  506.102 μs   1.57576
+  14 │ symbols     sha256     4          2.365 ms    3.576 ms     1.51254
+  15 │ missings    sha256     4          649.787 μs  692.879 μs   1.06632
+  16 │ strings     sha256     4          2.555 ms    2.159 ms     0.844936
+```


### PR DESCRIPTION
## Description

This makes the function concretely type-inferred.
On this PR
```julia
julia> @descend StableHashTraits.handle_unions_(Int, StableHashTraits.nameof_)
handle_unions_(::Type{T}, namer) where T @ StableHashTraits ~/Dropbox/JuliaPackages/StableHashTraits.jl/src/main_interface.jl:326
326 function (handle_unions_(::(Type{T})::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_)) where {T})::String
327     if (T::Type{Int64} isa Union)::Core.Const(false)
328         return _handle_unions_(T, namer)
329     end
330     return handle_function_types_(T::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))::String
331 end
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [w]arn, [h]ide type-stable statements, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native, [j]ump to source always.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
 • handle_function_types_(T::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))
 ```
 Compared to `main`:
 ```julia
julia> @descend StableHashTraits.handle_unions_(Int, StableHashTraits.nameof_)
handle_unions_(::Type{Union{A, B}}, namer) where {A, B} @ StableHashTraits ~/Dropbox/JuliaPackages/StableHashTraits_main/src/main_interface.jl:326
326 function (handle_unions_(::(Type{Union{A,B}})::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_)) where {A,B})::Union{Base.AnnotatedString{String}, String}
327     !(@isdefined(A::Type{Int64})::Core.Const(true))::Core.Const(false) && !@isdefined(B) && return ""
328     !(@isdefined(B)::Bool)::Bool && return handle_function_types_(A::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))::String
329     # NOTE: The following line never gets run, because of the way julia's type dispatch
330     # is currently implemented, but it is here to avoid regressions in future julia
331     # versions
332     !(@isdefined(A::Type{Int64})::Core.Const(true))::Core.Const(false) && return handle_function_types_(B, namer)
333     return (handle_unions_(A::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))::Union{Base.AnnotatedString{String}, String} * "," * handle_unions_(B::Type{B} where B<:Int64, namer::Core.Const(StableHashTraits.nameof_))::AbstractString)::Union{Base.AnnotatedString{String}, String}
334 end
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [w]arn, [h]ide type-stable statements, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native, [j]ump to source always.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
 • !@isdefined(A::Type{Int64})::Core.Const(true)
   !@isdefined(B)::Bool
   handle_function_types_(A::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))
   !@isdefined(A::Type{Int64})::Core.Const(true)
   handle_unions_(B::Type{B} where B<:Int64, namer::Core.Const(StableHashTraits.nameof_))
    handle_unions_(A::Type{Int64}, namer::Core.Const(StableHashTraits.nameof_))::Union{Base.AnnotatedString{String}, String} * "," * handle_unions_(B::Ty…
   ↩
 ```
This doesn't change the actual values.
On `main`:
```julia
julia> StableHashTraits.handle_unions_(Int, StableHashTraits.nameof_)
"Int64"

julia> StableHashTraits.handle_unions_(Union{Int,Float64}, StableHashTraits.nameof_)
"Float64,Int64"
```
This PR:
```julia
julia> StableHashTraits.handle_unions_(Int, StableHashTraits.nameof_)
"Int64"

julia> StableHashTraits.handle_unions_(Union{Int,Float64}, StableHashTraits.nameof_)
"Float64,Int64"
```

## Benchmarks

Author, please:

Run the benchmarks under `test/benchmarks.jl` locally, and update `test/benchmark_records.md` by inserting a new table at the end of the document with the updated numbers
printed at the end of the benchmark script. Place the table as it occurs before
and after the application of this PR.

### Before
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.614 ms    103.976 ms  64.4097
   2 │ structs     crc        4          16.579 μs   729.768 μs  44.0176
   3 │ tuples      crc        4          15.645 μs   561.723 μs  35.9043
   4 │ numbers     crc        4          6.201 μs    187.247 μs  30.1963
   5 │ dataframes  crc        4          25.714 μs   425.839 μs  16.5606
   6 │ symbols     crc        4          1.135 ms    1.665 ms     1.46723
   7 │ missings    crc        4          309.527 μs  324.696 μs   1.04901
   8 │ strings     crc        4          1.215 ms    325.599 μs   0.268001
   9 │ dicts       sha256     4          2.302 ms    140.651 ms  61.1039
  10 │ structs     sha256     4          643.641 μs  2.060 ms     3.20029
  11 │ tuples      sha256     4          614.356 μs  1.678 ms     2.73077
  12 │ dataframes  sha256     4          638.423 μs  1.049 ms     1.64309
  13 │ numbers     sha256     4          321.231 μs  500.670 μs   1.5586
  14 │ symbols     sha256     4          2.337 ms    3.609 ms     1.54436
  15 │ missings    sha256     4          679.789 μs  699.407 μs   1.02886
  16 │ strings     sha256     4          2.514 ms    2.203 ms     0.876061
```
### After
```julia
julia> include("test/benchmark.jl")
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.588 ms    102.622 ms  64.6296
   2 │ structs     crc        4          17.277 μs   752.080 μs  43.5307
   3 │ tuples      crc        4          17.358 μs   529.185 μs  30.4865
   4 │ numbers     crc        4          6.791 μs    186.629 μs  27.4818
   5 │ dataframes  crc        4          27.073 μs   438.643 μs  16.2022
   6 │ symbols     crc        4          1.168 ms    1.619 ms     1.38543
   7 │ missings    crc        4          302.562 μs  315.324 μs   1.04218
   8 │ strings     crc        4          1.223 ms    334.434 μs   0.273366
   9 │ dicts       sha256     4          2.281 ms    133.743 ms  58.6238
  10 │ structs     sha256     4          643.719 μs  2.024 ms     3.145
  11 │ tuples      sha256     4          628.626 μs  1.792 ms     2.8509
  12 │ dataframes  sha256     4          653.632 μs  1.084 ms     1.65908
  13 │ numbers     sha256     4          321.180 μs  506.102 μs   1.57576
  14 │ symbols     sha256     4          2.365 ms    3.576 ms     1.51254
  15 │ missings    sha256     4          649.787 μs  692.879 μs   1.06632
  16 │ strings     sha256     4          2.555 ms    2.159 ms     0.844936
```