### PR TITLE
Improve inference in `nameof_` by skipping `occursin`

### DIFF
--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -379,10 +379,10 @@ end
 end
 
 # known Base types
-for name in [Int8,Int16,Int32,Int64,Int128,BigInt,UInt8,UInt16,UInt32,UInt64,UInt128,Float16,Float32,Float64,BigFloat,Bool,Char,String,Symbol]
-    @eval maybe_validate_name(::Type{$name}, s) = s
+for name in unique(name -> getfield(Base, name), [name for name in names(Base) if Base.isstructtype(getfield(Base, name)) && !occursin("#", string(name))])
+    @eval maybe_validate_name(::Type{Base.$name}, s) = s
 end
-for name in [name for name in names(StructTypes, all=true) if Base.isstructtype(getfield(StructTypes, name)) && !occursin("#", string(name))]
+for name in unique(name -> getfield(StructTypes, name), [name for name in names(StructTypes, all=true) if Base.isstructtype(getfield(StructTypes, name)) && !occursin("#", string(name))])
     @eval maybe_validate_name(::Type{StructTypes.$name}, s) = s
 end
 maybe_validate_name(@nospecialize(::Any), s) = validate_name(s)


### PR DESCRIPTION
## Description

`occursin` has surprisingly poor inferred effects, and we may skip it for common types.
On `main`:
```julia
julia> InteractiveUtils.@infer_effects StableHashTraits.nameof_(Int)
(!c,!e,!n,!t,!s,!m,!u,+o,!r)
```
This PR
```julia
julia> InteractiveUtils.@infer_effects StableHashTraits.nameof_(Int)
(+c,+e,+n,+t,+s,+m,+u,+o,+r)
```
This allows the name to be evaluated as a constant at compile time.

## Benchmarks

This PR doesn't impact benchmarks substantially by itself. The benchmarks are quite noisy, so I haven't added these to `benchmark_records.md`.

### Before
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.592 ms    113.270 ms  71.165
   2 │ structs     crc        4          15.105 μs   723.853 μs  47.9214
   3 │ tuples      crc        4          15.840 μs   542.111 μs  34.2242
   4 │ numbers     crc        4          6.668 μs    200.536 μs  30.0744
   5 │ dataframes  crc        4          24.957 μs   425.591 μs  17.053
   6 │ symbols     crc        4          1.138 ms    1.816 ms     1.59581
   7 │ missings    crc        4          292.147 μs  325.892 μs   1.11551
   8 │ strings     crc        4          1.189 ms    315.910 μs   0.265668
   9 │ dicts       sha256     4          2.276 ms    156.442 ms  68.7501
  10 │ structs     sha256     4          614.276 μs  1.967 ms     3.2024
  11 │ tuples      sha256     4          614.723 μs  1.751 ms     2.84816
  12 │ dataframes  sha256     4          623.858 μs  1.048 ms     1.67979
  13 │ numbers     sha256     4          306.669 μs  501.906 μs   1.63664
  14 │ symbols     sha256     4          2.288 ms    3.487 ms     1.5243
  15 │ missings    sha256     4          654.760 μs  681.218 μs   1.04041
  16 │ strings     sha256     4          2.387 ms    2.101 ms     0.880286
```

### After
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          2.242 ms    147.613 ms  65.8456
   2 │ structs     crc        4          18.336 μs   983.920 μs  53.6606
   3 │ numbers     crc        4          7.679 μs    255.403 μs  33.2599
   4 │ tuples      crc        4          28.776 μs   688.961 μs  23.9422
   5 │ dataframes  crc        4          28.612 μs   525.767 μs  18.3758
   6 │ symbols     crc        4          1.449 ms    2.301 ms     1.58819
   7 │ missings    crc        4          354.165 μs  409.297 μs   1.15567
   8 │ strings     crc        4          1.554 ms    429.361 μs   0.276324
   9 │ dicts       sha256     4          3.192 ms    179.300 ms  56.1652
  10 │ tuples      sha256     4          643.821 μs  2.159 ms     3.35354
  11 │ missings    sha256     4          656.367 μs  1.952 ms     2.97374
  12 │ structs     sha256     4          878.904 μs  2.592 ms     2.94933
  13 │ dataframes  sha256     4          812.843 μs  1.651 ms     2.03102
  14 │ symbols     sha256     4          2.867 ms    5.077 ms     1.77105
  15 │ numbers     sha256     4          412.473 μs  606.498 μs   1.47039
  16 │ strings     sha256     4          3.052 ms    2.174 ms     0.712352
```