### PR TITLE
Type-stable transformer for types

### DIFF
--- a/src/main_interface.jl
+++ b/src/main_interface.jl
@@ -92,6 +92,10 @@ struct Transformer{F,H}
                          hoist_type=StableHashTraits.hoist_type(fn))
         return new{typeof(fn),typeof(result_method)}(fn, result_method, hoist_type)
     end
+    function Transformer(::Type{T}, result_method=nothing;
+                         hoist_type=StableHashTraits.hoist_type(fn)) where {T}
+        return new{Type{T},typeof(result_method)}(T, result_method, hoist_type)
+    end
 end
 (tr::Transformer)(x) = tr.fn(x)
 


### PR DESCRIPTION
## Description

This improves type stability in hashing `Symbol`s:
On main:
```julia
julia> @code_warntype stable_hash(:args, HashVersion{4}())
MethodInstance for stable_hash(::Symbol, ::HashVersion{4})
  from stable_hash(x, context; alg) @ StableHashTraits ~/Dropbox/JuliaPackages/StableHashTraits_main/src/main_interface.jl:45
Arguments
  #self#::Core.Const(StableHashTraits.stable_hash)
  x::Symbol
  context::Core.Const(HashVersion{4}())
Body::Any
1 ─ %1 = StableHashTraits.:(var"#stable_hash#2")::Core.Const(StableHashTraits.var"#stable_hash#2")
│   %2 = StableHashTraits.sha256::Core.Const(SHA.sha256)
│   %3 = (%1)(%2, #self#, x, context)::Any
└──      return %3
```
this PR
```julia
julia> @code_warntype stable_hash(:args, HashVersion{4}())
MethodInstance for stable_hash(::Symbol, ::HashVersion{4})
  from stable_hash(x, context; alg) @ StableHashTraits ~/Dropbox/JuliaPackages/StableHashTraits.jl/src/main_interface.jl:45
Arguments
  #self#::Core.Const(StableHashTraits.stable_hash)
  x::Symbol
  context::Core.Const(HashVersion{4}())
Body::Vector{UInt8}
1 ─ %1 = StableHashTraits.:(var"#stable_hash#2")::Core.Const(StableHashTraits.var"#stable_hash#2")
│   %2 = StableHashTraits.sha256::Core.Const(SHA.sha256)
│   %3 = (%1)(%2, #self#, x, context)::Vector{UInt8}
└──      return %3
```

## Benchmarks

### Before

```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.561 ms    111.695 ms  71.5736
   2 │ structs     crc        4          14.496 μs   746.545 μs  51.5001
   3 │ tuples      crc        4          14.941 μs   518.051 μs  34.6731
   4 │ numbers     crc        4          6.731 μs    198.427 μs  29.4796
   5 │ dataframes  crc        4          24.964 μs   440.441 μs  17.643
   6 │ symbols     crc        4          1.135 ms    1.652 ms     1.45629
   7 │ missings    crc        4          312.047 μs  332.651 μs   1.06603
   8 │ strings     crc        4          1.175 ms    335.505 μs   0.285465
   9 │ dicts       sha256     4          2.326 ms    147.516 ms  63.4304
  10 │ structs     sha256     4          613.673 μs  1.989 ms     3.24183
  11 │ tuples      sha256     4          614.276 μs  1.711 ms     2.78554
  12 │ dataframes  sha256     4          638.267 μs  1.061 ms     1.66207
  13 │ numbers     sha256     4          306.511 μs  505.354 μs   1.64873
  14 │ symbols     sha256     4          2.335 ms    3.395 ms     1.45406
  15 │ missings    sha256     4          659.888 μs  681.520 μs   1.03278
  16 │ strings     sha256     4          2.461 ms    2.058 ms     0.836287
```

### After
```julia
16×6 DataFrame
 Row │ benchmark   hash       version    base        trait       ratio     
     │ SubStrin…   SubStrin…  SubStrin…  String      String      Float64   
─────┼─────────────────────────────────────────────────────────────────────
   1 │ dicts       crc        4          1.510 ms    103.730 ms  68.6943
   2 │ structs     crc        4          14.730 μs   720.135 μs  48.889
   3 │ tuples      crc        4          14.739 μs   513.234 μs  34.8215
   4 │ numbers     crc        4          7.794 μs    181.437 μs  23.2791
   5 │ dataframes  crc        4          24.941 μs   424.429 μs  17.0173
   6 │ missings    crc        4          297.375 μs  312.065 μs   1.0494
   7 │ symbols     crc        4          1.130 ms    547.357 μs   0.484426
   8 │ strings     crc        4          1.186 ms    337.174 μs   0.284407
   9 │ dicts       sha256     4          2.242 ms    141.342 ms  63.0535
  10 │ structs     sha256     4          613.599 μs  1.931 ms     3.14629
  11 │ tuples      sha256     4          628.512 μs  1.742 ms     2.77234
  12 │ dataframes  sha256     4          638.208 μs  1.061 ms     1.66215
  13 │ numbers     sha256     4          313.729 μs  505.432 μs   1.61105
  14 │ missings    sha256     4          657.235 μs  677.751 μs   1.03122
  15 │ symbols     sha256     4          2.303 ms    2.249 ms     0.976493
  16 │ strings     sha256     4          2.458 ms    2.107 ms     0.857192
```